### PR TITLE
call AM_INIT_AUTOMAKE early

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 AC_INIT([gnome-initial-setup],[3.10.1.1])
+AM_INIT_AUTOMAKE([dist-xz no-dist-gzip foreign])
 AC_CONFIG_MACRO_DIR([m4])
 AC_USE_SYSTEM_EXTENSIONS
-AM_INIT_AUTOMAKE([dist-xz no-dist-gzip foreign])
 AM_SILENT_RULES([yes])
 LT_INIT
 AC_PROG_CC


### PR DESCRIPTION
Call AM_INIT_AUTOMAKE early to not break build with Automake >= 1.14, which else would use an undefined $ac_aux_dir.

This fixes the build for Fedora 21 development ( https://bugzilla.redhat.com/1028671 ).
